### PR TITLE
fix(PatchDecoder3d): special handling of the case where height is zero

### DIFF
--- a/paravae/models/WAN2_1/patch_vae.py
+++ b/paravae/models/WAN2_1/patch_vae.py
@@ -852,6 +852,16 @@ class PatchDecoder3d(nn.Module):
                
         x = split_forward_gather_backward(None, x, 3)
 
+        ZERO_HEIGHT = False
+        if x.shape[3] == 0:
+            ZERO_HEIGHT = True
+            x = torch.zeros(
+                [x.shape[0], x.shape[1], x.shape[2], 1, x.shape[4]],
+                dtype=x.dtype,
+                device=x.device,
+                requires_grad=x.requires_grad
+            )
+
         ## upsamples
         for layer in self.upsamples:
             if feat_cache is not None:
@@ -877,6 +887,14 @@ class PatchDecoder3d(nn.Module):
             else:
                 x = layer(x)
         
+        if ZERO_HEIGHT:
+            x = torch.zeros(
+                [x.shape[0], x.shape[1], x.shape[2], 0, x.shape[4]],
+                dtype=x.dtype,
+                device=x.device,
+                requires_grad=x.requires_grad
+            )
+
         x = gather_forward_split_backward(None, x, 3)
         
         return x


### PR DESCRIPTION
the example runs error when nproc_per_node=8, so fix it